### PR TITLE
docs: fix simple typo, veritcal -> vertical

### DIFF
--- a/lib/includes/IEmoStateDLL.h
+++ b/lib/includes/IEmoStateDLL.h
@@ -423,7 +423,7 @@ extern "C" {
 
         \param state - EmoStateHandle
         \param x - the horizontal position of the eyes
-        \param y - the veritcal position of the eyes
+        \param y - the vertical position of the eyes
 
     */
     EMOSTATE_DLL_API void


### PR DESCRIPTION
There is a small typo in lib/includes/IEmoStateDLL.h.

Should read `vertical` rather than `veritcal`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md